### PR TITLE
fix: proto schema update should update bq table

### DIFF
--- a/src/main/java/io/odpf/depot/message/proto/ProtoOdpfMessageParser.java
+++ b/src/main/java/io/odpf/depot/message/proto/ProtoOdpfMessageParser.java
@@ -92,4 +92,11 @@ public class ProtoOdpfMessageParser implements OdpfMessageParser {
         Set<Object> objects = new HashSet<>();
         return t -> objects.add(keyExtractor.apply(t));
     }
+
+    public OdpfMessageSchema getSchema(String schemaClass, Map<String, Descriptors.Descriptor> newDescriptors) throws IOException {
+        ProtoField protoField = new ProtoField();
+        protoField = protoMappingParser.parseFields(protoField, schemaClass, newDescriptors,
+                getTypeNameToPackageNameMap(newDescriptors));
+        return new ProtoOdpfMessageSchema(protoField);
+    }
 }

--- a/src/test/java/io/odpf/depot/bigquery/handler/MessageRecordConverterTest.java
+++ b/src/test/java/io/odpf/depot/bigquery/handler/MessageRecordConverterTest.java
@@ -48,9 +48,8 @@ public class MessageRecordConverterTest {
         Map<String, Descriptors.Descriptor> descriptorsMap = new HashMap<String, Descriptors.Descriptor>() {{
             put(String.format("%s", TestMessage.class.getName()), TestMessage.getDescriptor());
         }};
-        doReturn(descriptorsMap).when(stencilClient).getAll();
         ProtoOdpfMessageParser protoOdpfMessageParser = new ProtoOdpfMessageParser(stencilClient);
-        schema = protoOdpfMessageParser.getSchema("io.odpf.depot.TestMessage");
+        schema = protoOdpfMessageParser.getSchema("io.odpf.depot.TestMessage", descriptorsMap);
         recordConverter = new MessageRecordConverter(protoOdpfMessageParser,
                 ConfigFactory.create(BigQuerySinkConfig.class, System.getProperties()), schema);
 


### PR DESCRIPTION
This fixes the bug proto schema update propagation to BQ
Steps to reproduce the bug

1. Update the stencil proto schema to version 2 
2. Update the stencil proto schema to version 3

Expected

1. when proto schema updated to version 2 , the bq tables should be updated with fields in version 2.
2. when proto schema updated to version 3 , the bq tables should be updated with fields in version 3.

Actual
1. when proto schema updated to version 2 , the bq tables should be updated with fields in version 1.
2. when proto schema updated to version 3 , the bq tables should be updated with fields in version 2.


