### PR TITLE
fix: bigquery json sink duplicated fields error

### DIFF
--- a/src/main/java/io/odpf/depot/bigquery/handler/JsonErrorHandler.java
+++ b/src/main/java/io/odpf/depot/bigquery/handler/JsonErrorHandler.java
@@ -103,15 +103,21 @@ public class JsonErrorHandler implements ErrorHandler {
             throw new UnsupportedOperationException("metadata namespace is not supported, because nested json structure is not supported");
         }
         if (metadataColumnsTypesMap.containsKey(key)) {
-            return Field.of(key, LegacySQLTypeName.valueOfStrict(metadataColumnsTypesMap.get(key).toUpperCase()));
+            return Field.newBuilder(key, LegacySQLTypeName.valueOfStrict(metadataColumnsTypesMap.get(key).toUpperCase()))
+                    .setMode(Field.Mode.NULLABLE)
+                    .build();
         }
         if (defaultColumnsMap.containsKey(key)) {
-            return Field.of(key, LegacySQLTypeName.valueOfStrict(defaultColumnsMap.get(key).toUpperCase()));
+            return Field.newBuilder(key, LegacySQLTypeName.valueOfStrict(defaultColumnsMap.get(key).toUpperCase()))
+                    .setMode(Field.Mode.NULLABLE)
+                    .build();
         }
         if (!castAllColumnsToStringDataType) {
             throw new UnsupportedOperationException("only string data type is supported for fields other than partition key");
         }
-        return Field.of(key, LegacySQLTypeName.STRING);
+        return Field.newBuilder(key, LegacySQLTypeName.STRING)
+                .setMode(Field.Mode.NULLABLE)
+                .build();
     }
 
     private boolean filterExistingFields(FieldList existingFieldList, String key) {

--- a/src/main/java/io/odpf/depot/bigquery/json/BigqueryJsonUpdateListener.java
+++ b/src/main/java/io/odpf/depot/bigquery/json/BigqueryJsonUpdateListener.java
@@ -102,13 +102,13 @@ public class BigqueryJsonUpdateListener extends OdpfStencilUpdateListener {
     private Field checkAndCreateField(String fieldName, LegacySQLTypeName fieldDataType) {
         Boolean isPartitioningEnabled = config.isTablePartitioningEnabled();
         if (!isPartitioningEnabled) {
-            return Field.of(fieldName, fieldDataType);
+            return Field.newBuilder(fieldName, fieldDataType).setMode(Field.Mode.NULLABLE).build();
         }
         String partitionKey = config.getTablePartitionKey();
         boolean isValidPartitionDataType = (fieldDataType == LegacySQLTypeName.TIMESTAMP || fieldDataType == LegacySQLTypeName.DATE);
         if (partitionKey.equals(fieldName) && !isValidPartitionDataType) {
             throw new UnsupportedOperationException("supported partition fields have to be of DATE or TIMESTAMP type..");
         }
-        return Field.of(fieldName, fieldDataType);
+        return Field.newBuilder(fieldName, fieldDataType).setMode(Field.Mode.NULLABLE).build();
     }
 }

--- a/src/main/java/io/odpf/depot/bigquery/proto/BigqueryFields.java
+++ b/src/main/java/io/odpf/depot/bigquery/proto/BigqueryFields.java
@@ -25,6 +25,7 @@ public class BigqueryFields {
     public static List<Field> getMetadataFieldsStrict(List<TupleString> metadataColumnsTypes) {
         return metadataColumnsTypes.stream().map(
                 tuple -> Field.newBuilder(tuple.getFirst(), LegacySQLTypeName.valueOfStrict(tuple.getSecond().toUpperCase()))
+                        .setMode(Field.Mode.NULLABLE)
                         .build()).collect(Collectors.toList());
     }
 

--- a/src/test/java/io/odpf/depot/bigquery/handler/JsonErrorHandlerTest.java
+++ b/src/test/java/io/odpf/depot/bigquery/handler/JsonErrorHandlerTest.java
@@ -28,10 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class JsonErrorHandlerTest {
 
@@ -53,6 +50,10 @@ public class JsonErrorHandlerTest {
         MockitoAnnotations.initMocks(this);
     }
 
+    private Field getField(String name, LegacySQLTypeName type) {
+        return Field.newBuilder(name, type).setMode(Field.Mode.NULLABLE).build();
+    }
+
     @Test
     public void shouldUpdateTableFieldsOnSchemaError() {
         when(bigQueryClient.getSchema()).thenReturn(emptyTableSchema);
@@ -71,7 +72,7 @@ public class JsonErrorHandlerTest {
         jsonErrorHandler.handle(insertErrors, records);
         verify(bigQueryClient, times(1)).upsertTable(fieldsArgumentCaptor.capture());
 
-        Field firstName = Field.of("first_name", LegacySQLTypeName.STRING);
+        Field firstName = getField("first_name", LegacySQLTypeName.STRING);
         List<Field> actualFields = fieldsArgumentCaptor.getValue();
         assertThat(actualFields, containsInAnyOrder(firstName));
     }
@@ -127,8 +128,8 @@ public class JsonErrorHandlerTest {
 
         verify(bigQueryClient, times(1)).upsertTable(fieldsArgumentCaptor.capture());
 
-        Field firstName = Field.of("first_name", LegacySQLTypeName.STRING);
-        Field lastName = Field.of("last_name", LegacySQLTypeName.STRING);
+        Field firstName = getField("first_name", LegacySQLTypeName.STRING);
+        Field lastName = getField("last_name", LegacySQLTypeName.STRING);
         List<Field> actualFields = fieldsArgumentCaptor.getValue();
         assertThat(actualFields, containsInAnyOrder(firstName, lastName));
     }
@@ -158,7 +159,7 @@ public class JsonErrorHandlerTest {
 
         verify(bigQueryClient, times(1)).upsertTable(fieldsArgumentCaptor.capture());
 
-        Field lastName = Field.of("last_name", LegacySQLTypeName.STRING);
+        Field lastName = getField("last_name", LegacySQLTypeName.STRING);
         List<Field> actualFields = fieldsArgumentCaptor.getValue();
         assertThat(actualFields, containsInAnyOrder(lastName));
     }
@@ -186,7 +187,7 @@ public class JsonErrorHandlerTest {
 
         verify(bigQueryClient, times(1)).upsertTable(fieldsArgumentCaptor.capture());
 
-        Field lastName = Field.of("last_name", LegacySQLTypeName.STRING);
+        Field lastName = getField("last_name", LegacySQLTypeName.STRING);
         List<Field> actualFields = fieldsArgumentCaptor.getValue();
         assertThat(actualFields, containsInAnyOrder(lastName));
     }
@@ -198,9 +199,9 @@ public class JsonErrorHandlerTest {
 
         BigQueryError noSuchFieldError = new BigQueryError("invalid", "first_name", "no such field: first_name");
         Map<Long, List<BigQueryError>> errorInfoMap = ImmutableMap.of(
-        0L, Collections.singletonList(noSuchFieldError),
-        1L, Collections.singletonList(noSuchFieldError),
-        2L, Collections.singletonList(noSuchFieldError));
+                0L, Collections.singletonList(noSuchFieldError),
+                1L, Collections.singletonList(noSuchFieldError),
+                2L, Collections.singletonList(noSuchFieldError));
 
         Record validRecordWithFirstName = Record.builder()
                 .columns(ImmutableMap.of("first_name", "john doe"))
@@ -221,8 +222,8 @@ public class JsonErrorHandlerTest {
 
         verify(bigQueryClient, times(1)).upsertTable(fieldsArgumentCaptor.capture());
 
-        Field lastName = Field.of("last_name", LegacySQLTypeName.STRING);
-        Field firstName = Field.of("first_name", LegacySQLTypeName.STRING);
+        Field lastName = getField("last_name", LegacySQLTypeName.STRING);
+        Field firstName = getField("first_name", LegacySQLTypeName.STRING);
         List<Field> actualFields = fieldsArgumentCaptor.getValue();
         assertThat(actualFields, containsInAnyOrder(firstName, lastName));
     }
@@ -230,21 +231,21 @@ public class JsonErrorHandlerTest {
     @Test
     public void shouldUpdatWithBothMissingFieldsAndExistingTableFields() {
         //existing table fields
-        Field lastName = Field.of("last_name", LegacySQLTypeName.STRING);
-        Field firstName = Field.of("first_name", LegacySQLTypeName.STRING);
+        Field lastName = getField("last_name", LegacySQLTypeName.STRING);
+        Field firstName = getField("first_name", LegacySQLTypeName.STRING);
 
         Schema nonEmptyTableSchema = Schema.of(firstName, lastName);
         when(bigQueryClient.getSchema()).thenReturn(nonEmptyTableSchema);
 
         BigQueryError noSuchFieldError = new BigQueryError("invalid", "first_name", "no such field: first_name");
         Map<Long, List<BigQueryError>> errorInfoMap = ImmutableMap.of(
-        0L, Collections.singletonList(noSuchFieldError),
-        1L, Collections.singletonList(noSuchFieldError),
-        2L, Collections.singletonList(noSuchFieldError));
+                0L, Collections.singletonList(noSuchFieldError),
+                1L, Collections.singletonList(noSuchFieldError),
+                2L, Collections.singletonList(noSuchFieldError));
 
         Map<String, Object> columnsMapWithFistName = ImmutableMap.of(
-        "first_name", "john doe",
-        "newFieldAddress", "planet earth");
+                "first_name", "john doe",
+                "newFieldAddress", "planet earth");
         Record validRecordWithFirstName = Record.builder()
                 .columns(columnsMapWithFistName)
                 .build();
@@ -264,8 +265,8 @@ public class JsonErrorHandlerTest {
         verify(bigQueryClient, times(1)).upsertTable(fieldsArgumentCaptor.capture());
 
         //missing fields
-        Field newFieldDog = Field.of("newFieldDog", LegacySQLTypeName.STRING);
-        Field newFieldAddress = Field.of("newFieldAddress", LegacySQLTypeName.STRING);
+        Field newFieldDog = getField("newFieldDog", LegacySQLTypeName.STRING);
+        Field newFieldAddress = getField("newFieldAddress", LegacySQLTypeName.STRING);
 
         List<Field> actualFields = fieldsArgumentCaptor.getValue();
         assertThat(actualFields, containsInAnyOrder(firstName, lastName, newFieldDog, newFieldAddress));
@@ -278,24 +279,24 @@ public class JsonErrorHandlerTest {
 
         BigQueryError noSuchFieldError = new BigQueryError("invalid", "first_name", "no such field: first_name");
         Map<Long, List<BigQueryError>> errorInfoMap = ImmutableMap.of(
-        0L, Collections.singletonList(noSuchFieldError),
-        1L, Collections.singletonList(noSuchFieldError));
+                0L, Collections.singletonList(noSuchFieldError),
+                1L, Collections.singletonList(noSuchFieldError));
 
         Record validRecordWithFirstName = Record.builder()
                 .columns(ImmutableMap.of("first_name", "john doe"))
                 .build();
 
         Map<String, Object> columnsMapWithTimestamp = ImmutableMap.of(
-        "last_name", "john carmack",
-        "event_timestamp_partition", "today's date");
+                "last_name", "john carmack",
+                "event_timestamp_partition", "today's date");
         Record validRecordWithLastName = Record.builder().columns(columnsMapWithTimestamp).build();
 
         List<Record> validRecords = ImmutableList.of(validRecordWithFirstName, validRecordWithLastName);
 
         Map<String, String> envMap = ImmutableMap.of(
-            "SINK_BIGQUERY_TABLE_PARTITIONING_ENABLE", "true",
-            "SINK_BIGQUERY_TABLE_PARTITION_KEY", "event_timestamp_partition",
-            "SINK_BIGQUERY_DEFAULT_COLUMNS", "event_timestamp_partition=timestamp");
+                "SINK_BIGQUERY_TABLE_PARTITIONING_ENABLE", "true",
+                "SINK_BIGQUERY_TABLE_PARTITION_KEY", "event_timestamp_partition",
+                "SINK_BIGQUERY_DEFAULT_COLUMNS", "event_timestamp_partition=timestamp");
         BigQuerySinkConfig partitionKeyConfig = ConfigFactory.create(BigQuerySinkConfig.class, envMap);
         JsonErrorHandler jsonErrorHandler = new JsonErrorHandler(bigQueryClient, partitionKeyConfig, instrumentation);
         jsonErrorHandler.handle(errorInfoMap, validRecords);
@@ -303,9 +304,9 @@ public class JsonErrorHandlerTest {
 
         verify(bigQueryClient, times(1)).upsertTable(fieldsArgumentCaptor.capture());
 
-        Field firstName = Field.of("first_name", LegacySQLTypeName.STRING);
-        Field lastName = Field.of("last_name", LegacySQLTypeName.STRING);
-        Field eventTimestamp = Field.of("event_timestamp_partition", LegacySQLTypeName.TIMESTAMP);
+        Field firstName = getField("first_name", LegacySQLTypeName.STRING);
+        Field lastName = getField("last_name", LegacySQLTypeName.STRING);
+        Field eventTimestamp = getField("event_timestamp_partition", LegacySQLTypeName.TIMESTAMP);
         List<Field> actualFields = fieldsArgumentCaptor.getValue();
         assertThat(actualFields, containsInAnyOrder(firstName, lastName, eventTimestamp));
     }
@@ -323,7 +324,7 @@ public class JsonErrorHandlerTest {
 
         List<Record> records = Collections.singletonList(validRecord);
         BigQuerySinkConfig stringDisableConfig = ConfigFactory.create(BigQuerySinkConfig.class, ImmutableMap.of(
-            "SINK_BIGQUERY_DEFAULT_DATATYPE_STRING_ENABLE", "false"));
+                "SINK_BIGQUERY_DEFAULT_DATATYPE_STRING_ENABLE", "false"));
         JsonErrorHandler jsonErrorHandler = new JsonErrorHandler(bigQueryClient, stringDisableConfig, instrumentation);
         assertThrows(UnsupportedOperationException.class, () -> jsonErrorHandler.handle(errorInfoMap, records));
 
@@ -333,23 +334,23 @@ public class JsonErrorHandlerTest {
     @Test
     public void shouldUpdateMissingMetadataFields() {
         //existing table fields
-        Field lastName = Field.of("last_name", LegacySQLTypeName.STRING);
-        Field firstName = Field.of("first_name", LegacySQLTypeName.STRING);
+        Field lastName = getField("last_name", LegacySQLTypeName.STRING);
+        Field firstName = getField("first_name", LegacySQLTypeName.STRING);
 
         Schema nonEmptyTableSchema = Schema.of(firstName, lastName);
         when(bigQueryClient.getSchema()).thenReturn(nonEmptyTableSchema);
 
         BigQueryError noSuchFieldError = new BigQueryError("invalid", "first_name", "no such field: first_name");
         Map<Long, List<BigQueryError>> errorInfoMap = ImmutableMap.of(
-        0L, Collections.singletonList(noSuchFieldError),
-        1L, Collections.singletonList(noSuchFieldError),
-        2L, Collections.singletonList(noSuchFieldError));
+                0L, Collections.singletonList(noSuchFieldError),
+                1L, Collections.singletonList(noSuchFieldError),
+                2L, Collections.singletonList(noSuchFieldError));
 
         Map<String, Object> columnsMapWithFistName = ImmutableMap.of(
-        "first_name", "john doe",
-        "newFieldAddress", "planet earth",
-        "message_offset", 111,
-        "load_time", new DateTime(System.currentTimeMillis()));
+                "first_name", "john doe",
+                "newFieldAddress", "planet earth",
+                "message_offset", 111,
+                "load_time", new DateTime(System.currentTimeMillis()));
         Record validRecordWithFirstName = Record.builder()
                 .columns(columnsMapWithFistName)
                 .metadata(ImmutableMap.of(
@@ -358,9 +359,9 @@ public class JsonErrorHandlerTest {
                 .build();
 
         Map<String, Object> columnsMapWithNewFieldDog = ImmutableMap.of(
-        "newFieldDog", "golden retriever",
-        "load_time", new DateTime(System.currentTimeMillis()),
-        "message_offset", 11);
+                "newFieldDog", "golden retriever",
+                "load_time", new DateTime(System.currentTimeMillis()),
+                "message_offset", 11);
         Record validRecordWithLastName = Record.builder()
                 .columns(columnsMapWithNewFieldDog)
                 .metadata(ImmutableMap.of(
@@ -382,11 +383,11 @@ public class JsonErrorHandlerTest {
         verify(bigQueryClient, times(1)).upsertTable(fieldsArgumentCaptor.capture());
 
         //missing fields
-        Field newFieldDog = Field.of("newFieldDog", LegacySQLTypeName.STRING);
-        Field newFieldAddress = Field.of("newFieldAddress", LegacySQLTypeName.STRING);
+        Field newFieldDog = getField("newFieldDog", LegacySQLTypeName.STRING);
+        Field newFieldAddress = getField("newFieldAddress", LegacySQLTypeName.STRING);
 
-        Field messageOffset = Field.of("message_offset", LegacySQLTypeName.INTEGER);
-        Field loadTime = Field.of("load_time", LegacySQLTypeName.TIMESTAMP);
+        Field messageOffset = getField("message_offset", LegacySQLTypeName.INTEGER);
+        Field loadTime = getField("load_time", LegacySQLTypeName.TIMESTAMP);
         List<Field> actualFields = fieldsArgumentCaptor.getValue();
         assertThat(actualFields,
                 containsInAnyOrder(messageOffset, loadTime, firstName, lastName, newFieldDog, newFieldAddress));
@@ -395,8 +396,8 @@ public class JsonErrorHandlerTest {
     @Test
     public void shouldUpdateMissingMetadataFieldsAndDefaultColumns() {
         //existing table fields
-        Field lastName = Field.of("last_name", LegacySQLTypeName.STRING);
-        Field firstName = Field.of("first_name", LegacySQLTypeName.STRING);
+        Field lastName = getField("last_name", LegacySQLTypeName.STRING);
+        Field firstName = getField("first_name", LegacySQLTypeName.STRING);
 
         Schema nonEmptyTableSchema = Schema.of(firstName, lastName);
         when(bigQueryClient.getSchema()).thenReturn(nonEmptyTableSchema);
@@ -446,12 +447,12 @@ public class JsonErrorHandlerTest {
         verify(bigQueryClient, times(1)).upsertTable(fieldsArgumentCaptor.capture());
 
         //missing fields
-        Field newFieldDog = Field.of("newFieldDog", LegacySQLTypeName.STRING);
-        Field newFieldAddress = Field.of("newFieldAddress", LegacySQLTypeName.STRING);
+        Field newFieldDog = getField("newFieldDog", LegacySQLTypeName.STRING);
+        Field newFieldAddress = getField("newFieldAddress", LegacySQLTypeName.STRING);
 
-        Field messageOffset = Field.of("message_offset", LegacySQLTypeName.INTEGER);
-        Field loadTime = Field.of("load_time", LegacySQLTypeName.TIMESTAMP);
-        Field depot = Field.of("depot", LegacySQLTypeName.INTEGER);
+        Field messageOffset = getField("message_offset", LegacySQLTypeName.INTEGER);
+        Field loadTime = getField("load_time", LegacySQLTypeName.TIMESTAMP);
+        Field depot = getField("depot", LegacySQLTypeName.INTEGER);
         List<Field> actualFields = fieldsArgumentCaptor.getValue();
         assertThat(actualFields,
                 containsInAnyOrder(messageOffset, loadTime, firstName, lastName, newFieldDog, newFieldAddress, depot));
@@ -460,8 +461,8 @@ public class JsonErrorHandlerTest {
     @Test
     public void shouldNotAddMetadataFieldsWhenDisabled() {
         //existing table fields
-        Field lastName = Field.of("last_name", LegacySQLTypeName.STRING);
-        Field firstName = Field.of("first_name", LegacySQLTypeName.STRING);
+        Field lastName = getField("last_name", LegacySQLTypeName.STRING);
+        Field firstName = getField("first_name", LegacySQLTypeName.STRING);
 
         Schema nonEmptyTableSchema = Schema.of(firstName, lastName);
         when(bigQueryClient.getSchema()).thenReturn(nonEmptyTableSchema);
@@ -506,8 +507,8 @@ public class JsonErrorHandlerTest {
         verify(bigQueryClient, times(1)).upsertTable(fieldsArgumentCaptor.capture());
 
         //missing fields
-        Field newFieldDog = Field.of("newFieldDog", LegacySQLTypeName.STRING);
-        Field newFieldAddress = Field.of("newFieldAddress", LegacySQLTypeName.STRING);
+        Field newFieldDog = getField("newFieldDog", LegacySQLTypeName.STRING);
+        Field newFieldAddress = getField("newFieldAddress", LegacySQLTypeName.STRING);
 
         List<Field> actualFields = fieldsArgumentCaptor.getValue();
         assertThat(actualFields,
@@ -517,8 +518,8 @@ public class JsonErrorHandlerTest {
     @Test
     public void shouldThrowErrorForNamespacedMetadataNotSupported() {
         //existing table fields
-        Field lastName = Field.of("last_name", LegacySQLTypeName.STRING);
-        Field firstName = Field.of("first_name", LegacySQLTypeName.STRING);
+        Field lastName = getField("last_name", LegacySQLTypeName.STRING);
+        Field firstName = getField("first_name", LegacySQLTypeName.STRING);
 
         Schema nonEmptyTableSchema = Schema.of(firstName, lastName);
         when(bigQueryClient.getSchema()).thenReturn(nonEmptyTableSchema);
@@ -530,16 +531,16 @@ public class JsonErrorHandlerTest {
                 2L, Collections.singletonList(noSuchFieldError));
 
         Map<String, Object> columnsMapWithFistName = ImmutableMap.of(
-        "first_name", "john doe",
-        "newFieldAddress", "planet earth",
-        "message_offset", 111);
+                "first_name", "john doe",
+                "newFieldAddress", "planet earth",
+                "message_offset", 111);
         Record validRecordWithFirstName = Record.builder()
                 .columns(columnsMapWithFistName)
                 .build();
 
         Map<String, Object> columnsMapWithNewFieldDog = ImmutableMap.of(
-        "newFieldDog", "golden retriever",
-        "load_time", new DateTime(System.currentTimeMillis()));
+                "newFieldDog", "golden retriever",
+                "load_time", new DateTime(System.currentTimeMillis()));
         Record validRecordWithLastName = Record.builder()
                 .columns(columnsMapWithNewFieldDog)
                 .build();

--- a/src/test/java/io/odpf/depot/bigquery/json/BigqueryJsonUpdateListenerTest.java
+++ b/src/test/java/io/odpf/depot/bigquery/json/BigqueryJsonUpdateListenerTest.java
@@ -62,8 +62,8 @@ public class BigqueryJsonUpdateListenerTest {
         BigqueryJsonUpdateListener bigqueryJsonUpdateListener = new BigqueryJsonUpdateListener(config, converterCache, mockBqClient, instrumentation);
         bigqueryJsonUpdateListener.updateSchema();
         List<Field> bqSchemaFields = ImmutableList.of(
-                Field.of("event_timestamp", LegacySQLTypeName.TIMESTAMP),
-                Field.of("first_name", LegacySQLTypeName.STRING));
+                Field.newBuilder("event_timestamp", LegacySQLTypeName.TIMESTAMP).setMode(Field.Mode.NULLABLE).build(),
+                Field.newBuilder("first_name", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build());
         verify(mockBqClient, times(1)).upsertTable(bqSchemaFields);
     }
 
@@ -78,11 +78,12 @@ public class BigqueryJsonUpdateListenerTest {
         BigqueryJsonUpdateListener bigqueryJsonUpdateListener = new BigqueryJsonUpdateListener(config, converterCache, mockBqClient, instrumentation);
         bigqueryJsonUpdateListener.updateSchema();
         List<Field> bqSchemaFields = ImmutableList.of(
-                Field.of("event_timestamp", LegacySQLTypeName.TIMESTAMP),
-                Field.of("first_name", LegacySQLTypeName.STRING),
-                Field.of("message_offset", LegacySQLTypeName.INTEGER),
-                Field.of("message_topic", LegacySQLTypeName.STRING),
-                Field.of("message_timestamp", LegacySQLTypeName.TIMESTAMP));
+                Field.newBuilder("event_timestamp", LegacySQLTypeName.TIMESTAMP).setMode(Field.Mode.NULLABLE).build(),
+                Field.newBuilder("first_name", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build(),
+                Field.newBuilder("message_offset", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build(),
+                Field.newBuilder("message_topic", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build(),
+                Field.newBuilder("message_timestamp", LegacySQLTypeName.TIMESTAMP).setMode(Field.Mode.NULLABLE).build()
+        );
         ArgumentCaptor<List<Field>> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
         verify(mockBqClient, times(1)).upsertTable(listArgumentCaptor.capture());
         assertThat(listArgumentCaptor.getValue(), containsInAnyOrder(bqSchemaFields.toArray()));
@@ -100,11 +101,11 @@ public class BigqueryJsonUpdateListenerTest {
         BigqueryJsonUpdateListener bigqueryJsonUpdateListener = new BigqueryJsonUpdateListener(config, converterCache, mockBqClient, instrumentation);
         bigqueryJsonUpdateListener.updateSchema();
         List<Field> bqSchemaFields = ImmutableList.of(
-                Field.of("event_timestamp", LegacySQLTypeName.TIMESTAMP),
-                Field.of("first_name", LegacySQLTypeName.INTEGER),
-                Field.of("message_offset", LegacySQLTypeName.INTEGER),
-                Field.of("message_topic", LegacySQLTypeName.STRING),
-                Field.of("message_timestamp", LegacySQLTypeName.TIMESTAMP));
+                Field.newBuilder("event_timestamp", LegacySQLTypeName.TIMESTAMP).setMode(Field.Mode.NULLABLE).build(),
+                Field.newBuilder("first_name", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build(),
+                Field.newBuilder("message_offset", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build(),
+                Field.newBuilder("message_topic", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build(),
+                Field.newBuilder("message_timestamp", LegacySQLTypeName.TIMESTAMP).setMode(Field.Mode.NULLABLE).build());
         ArgumentCaptor<List<Field>> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
         verify(mockBqClient, times(1)).upsertTable(listArgumentCaptor.capture());
         assertThat(listArgumentCaptor.getValue(), containsInAnyOrder(bqSchemaFields.toArray()));
@@ -121,8 +122,8 @@ public class BigqueryJsonUpdateListenerTest {
         BigqueryJsonUpdateListener bigqueryJsonUpdateListener = new BigqueryJsonUpdateListener(config, converterCache, mockBqClient, instrumentation);
         bigqueryJsonUpdateListener.updateSchema();
         List<Field> bqSchemaFields = ImmutableList.of(
-                Field.of("event_timestamp", LegacySQLTypeName.TIMESTAMP),
-                Field.of("first_name", LegacySQLTypeName.STRING));
+                Field.newBuilder("event_timestamp", LegacySQLTypeName.TIMESTAMP).setMode(Field.Mode.NULLABLE).build(),
+                Field.newBuilder("first_name", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build());
         ArgumentCaptor<List<Field>> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
         verify(mockBqClient, times(1)).upsertTable(listArgumentCaptor.capture());
         assertThat(listArgumentCaptor.getValue(), containsInAnyOrder(bqSchemaFields.toArray()));
@@ -166,8 +167,8 @@ public class BigqueryJsonUpdateListenerTest {
         ArgumentCaptor<List<Field>> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
         verify(mockBqClient, times(1)).upsertTable(listArgumentCaptor.capture());
         List<Field> actualFields = listArgumentCaptor.getValue();
-        Field eventTimestampField = Field.of("event_timestamp", LegacySQLTypeName.TIMESTAMP);
-        Field firstNameField = Field.of("first_name", LegacySQLTypeName.STRING);
+        Field eventTimestampField = Field.newBuilder("event_timestamp", LegacySQLTypeName.TIMESTAMP).setMode(Field.Mode.NULLABLE).build();
+        Field firstNameField = Field.newBuilder("first_name", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build();
         assertThat(actualFields, containsInAnyOrder(eventTimestampField, firstNameField, existingField1, existingField2));
     }
 
@@ -182,8 +183,8 @@ public class BigqueryJsonUpdateListenerTest {
         BigqueryJsonUpdateListener bigqueryJsonUpdateListener = new BigqueryJsonUpdateListener(config, converterCache, mockBqClient, instrumentation);
         bigqueryJsonUpdateListener.updateSchema();
         List<Field> bqSchemaFields = ImmutableList.of(
-                Field.of("event_timestamp", LegacySQLTypeName.TIMESTAMP),
-                Field.of("first_name", LegacySQLTypeName.STRING));
+                Field.newBuilder("event_timestamp", LegacySQLTypeName.TIMESTAMP).setMode(Field.Mode.NULLABLE).build(),
+                Field.newBuilder("first_name", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build());
         verify(mockBqClient, times(1)).upsertTable(bqSchemaFields);
     }
 


### PR DESCRIPTION
This fixes the issue when default metadata columns are mentioned in the config, they are not treated as duplicates while adding to set collection