### PR TITLE
feat: add support for publishing statsd tags in native statsd format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.17'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.7"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:5.2.5"
         classpath "org.ajoberstar:gradle-git:1.6.0"
     }
 }
@@ -22,7 +22,7 @@ plugins {
 }
 
 group 'org.raystack'
-version '0.4.0'
+version '0.4.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/org/raystack/depot/config/MetricsConfig.java
+++ b/src/main/java/org/raystack/depot/config/MetricsConfig.java
@@ -18,5 +18,5 @@ public interface MetricsConfig extends Config {
 
     @Config.Key("METRIC_STATSD_TAGS_NATIVE_FORMAT_ENABLE")
     @DefaultValue("false")
-    Boolean getMetricStatsDTagsNativeFormatEnabled();
+    boolean getMetricStatsDTagsNativeFormatEnabled();
 }

--- a/src/main/java/org/raystack/depot/config/MetricsConfig.java
+++ b/src/main/java/org/raystack/depot/config/MetricsConfig.java
@@ -15,4 +15,8 @@ public interface MetricsConfig extends Config {
     @Config.Key("METRIC_STATSD_TAGS")
     @DefaultValue("")
     String getMetricStatsDTags();
+
+    @Config.Key("METRIC_STATSD_TAGS_NATIVE_FORMAT_ENABLE")
+    @DefaultValue("false")
+    Boolean getMetricStatsDTagsNativeFormatEnabled();
 }

--- a/src/main/java/org/raystack/depot/metrics/StatsDReporter.java
+++ b/src/main/java/org/raystack/depot/metrics/StatsDReporter.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 public class StatsDReporter implements Closeable {
 
     private final StatsDClient client;
-    private final Boolean tagsNativeFormatEnabled;
+    private final boolean tagsNativeFormatEnabled;
     private static final Logger LOGGER = LoggerFactory.getLogger(StatsDReporter.class);
     private final String[] globalTags;
 

--- a/src/main/java/org/raystack/depot/metrics/StatsDReporter.java
+++ b/src/main/java/org/raystack/depot/metrics/StatsDReporter.java
@@ -69,7 +69,7 @@ public class StatsDReporter implements Closeable {
             return null;
         }
         List<String> list = Arrays.stream(tags).map(s -> s.replaceAll("=", ":")).collect(Collectors.toList());
-        list.addAll(Arrays.stream(this.getGlobalTags().split(",")).collect(Collectors.toList()));
+        list.addAll(Arrays.asList(this.getGlobalTags().split(",")));
         return list.toArray(new String[0]);
     }
 

--- a/src/main/java/org/raystack/depot/metrics/StatsDReporter.java
+++ b/src/main/java/org/raystack/depot/metrics/StatsDReporter.java
@@ -69,7 +69,7 @@ public class StatsDReporter implements Closeable {
             return null;
         }
         List<String> list = Arrays.stream(tags).map(s -> s.replaceAll("=", ":")).collect(Collectors.toList());
-        list.add(this.getGlobalTags());
+        list.addAll(Arrays.stream(this.getGlobalTags().split(",")).collect(Collectors.toList()));
         return list.toArray(new String[0]);
     }
 
@@ -79,7 +79,7 @@ public class StatsDReporter implements Closeable {
 
     private String getGlobalTags() {
         if (this.tagsNativeFormatEnabled) {
-            return String.join("", this.globalTags).replaceAll("=", ":");
+            return String.join(",", this.globalTags).replaceAll("=", ":");
         }
         return String.join(",", this.globalTags).replaceAll(":", "=");
     }

--- a/src/main/java/org/raystack/depot/metrics/StatsDReporter.java
+++ b/src/main/java/org/raystack/depot/metrics/StatsDReporter.java
@@ -8,18 +8,28 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class StatsDReporter implements Closeable {
 
     private final StatsDClient client;
-    private final String globalTags;
+    private final Boolean tagsNativeFormatEnabled;
     private static final Logger LOGGER = LoggerFactory.getLogger(StatsDReporter.class);
+    private final String[] globalTags;
+
+    public StatsDReporter(StatsDClient client, Boolean tagsNativeFormatEnabled, String... globalTags) {
+        this.client = client;
+        this.tagsNativeFormatEnabled = tagsNativeFormatEnabled;
+        this.globalTags = globalTags;
+    }
 
     public StatsDReporter(StatsDClient client, String... globalTags) {
         this.client = client;
-        this.globalTags = String.join(",", globalTags).replaceAll(":", "=");
+        this.tagsNativeFormatEnabled = false;
+        this.globalTags = globalTags;
     }
 
     public StatsDClient getClient() {
@@ -27,41 +37,61 @@ public class StatsDReporter implements Closeable {
     }
 
     public void captureCount(String metric, Long delta, String... tags) {
-        client.count(withTags(metric, tags), delta);
+        client.count(getMetrics(metric, tags), delta, getTags(tags));
     }
 
     public void captureHistogram(String metric, long delta, String... tags) {
-        client.time(withTags(metric, tags), delta);
+        client.time(getMetrics(metric, tags), delta, getTags(tags));
     }
 
     public void captureDurationSince(String metric, Instant startTime, String... tags) {
-        client.recordExecutionTime(withTags(metric, tags), Duration.between(startTime, Instant.now()).toMillis());
+        client.recordExecutionTime(getMetrics(metric, tags), Duration.between(startTime, Instant.now()).toMillis(), getTags(tags));
     }
 
     public void captureDuration(String metric, long duration, String... tags) {
-        client.recordExecutionTime(withTags(metric, tags), duration);
+        client.recordExecutionTime(getMetrics(metric, tags), duration, getTags(tags));
     }
 
     public void gauge(String metric, Integer value, String... tags) {
-        client.gauge(withTags(metric, tags), value);
+        client.gauge(getMetrics(metric, tags), value, getTags(tags));
     }
 
     public void increment(String metric, String... tags) {
-        captureCount(metric, 1L, tags);
+        captureCount(metric, 1L, getTags(tags));
     }
 
     public void recordEvent(String metric, String eventName, String... tags) {
-        client.recordSetValue(withTags(metric, tags), eventName);
+        client.recordSetValue(getMetrics(metric, tags), eventName, getTags(tags));
     }
 
-    private String withGlobalTags(String metric) {
-        return metric + "," + this.globalTags;
+    private String[] getTags(String[] tags) {
+        if (!this.tagsNativeFormatEnabled) {
+            return null;
+        }
+        List<String> list = Arrays.stream(tags).map(s -> s.replaceAll("=", ":")).collect(Collectors.toList());
+        list.add(this.getGlobalTags());
+        return list.toArray(new String[0]);
+    }
+
+    private String getMetrics(String metric, String... tags) {
+        return this.tagsNativeFormatEnabled ? metric : withTags(metric, tags);
+    }
+
+    private String getGlobalTags() {
+        if (this.tagsNativeFormatEnabled) {
+            return String.join("", this.globalTags).replaceAll("=", ":");
+        }
+        return String.join(",", this.globalTags).replaceAll(":", "=");
     }
 
     private String withTags(String metric, String... tags) {
-        return Stream.concat(Stream.of(withGlobalTags(metric)), Stream.of(tags))
+        return Stream.concat(
+                        Stream.of(metric + "," + this.getGlobalTags()),
+                        tags == null ? Stream.empty() : Arrays.stream(tags)
+                )
                 .collect(Collectors.joining(","));
     }
+
 
     @Override
     public void close() throws IOException {

--- a/src/main/java/org/raystack/depot/metrics/StatsDReporterBuilder.java
+++ b/src/main/java/org/raystack/depot/metrics/StatsDReporterBuilder.java
@@ -47,7 +47,7 @@ public class StatsDReporterBuilder {
 
     public StatsDReporter build() {
         StatsDClient statsDClient = buildStatsDClient();
-        return new StatsDReporter(statsDClient, append(metricsConfig.getMetricStatsDTags().split(","), extraTags));
+        return new StatsDReporter(statsDClient, metricsConfig.getMetricStatsDTagsNativeFormatEnabled(),  append(metricsConfig.getMetricStatsDTags().split(","), extraTags));
     }
 
     private StatsDClient buildStatsDClient() {


### PR DESCRIPTION
Currently, we are publishing statsd tags that work only with Telegraf and Influx DB setup.

This PR adds a flag based support for native stated tags format.